### PR TITLE
took vcxproj filter out of .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,6 +348,3 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
-
-# Extra! Something probably from Visual Studio 2019
-*.vcxproj*


### PR DESCRIPTION
This seems to be important for displaying folder structure in Visual Studio